### PR TITLE
Fix two supid mistake when making back the default running mode witho…

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -32,6 +32,9 @@ int main(int argc, char* argv[]) {
   boost::program_options::options_description desc("Options");
 
   desc.add_options()("help,h", "Print help messages.")(
+    "id,i",
+    boost::program_options::value<int>(&id)->required(),
+    "Process ID.")(
     "configuration,c",
     boost::program_options::value<std::string>(&str_conf)->required(),
     "Configuration JSON file.");

--- a/transport/endpoints.h
+++ b/transport/endpoints.h
@@ -55,6 +55,7 @@ class Endpoint {
         it->second.get < std::string > ("HOST"),
         it->second.get < std::string > ("PORT"));
     }
+    return endpoints;
   }
 #endif //HAVE_HYDRA
 


### PR DESCRIPTION
Ok, I added back again the missing -i options I removed when adding hydra. And a missing return statement in get_endpoints when running without hydra.